### PR TITLE
Python3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 *laika* is a business reporting library that allows you to request data from different sources and send it to someone or save it at some destination. For example: you can query your database, send the result as an excel attachment via email and save it on Google Drive or Amazon S3.
 
+Check out the documentation at [readthedocs](http://laika.readthedocs.io/en/latest/index.html>).
+
 <!-- TODO: document what it is and what it is not -->
+
+Laika was tested on Python 2.7 and 3.5 or higher.
 
 ## Installation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,9 +12,11 @@ destination. For example: you can query your database, send the result
 as an excel attachment via email and save it on Google Drive or Amazon
 S3.
 
-Check out the documentation at [readthedocs](http://laika.readthedocs.io/en/latest/index.html).
+Check out the documentation at `readthedocs <http://laika.readthedocs.io/en/latest/index.html>`_.
 
 .. TODO: document what it is and what it is not
+
+Laika was tested on Python 2.7 and 3.5 or higher.
 
 Installation
 ------------

--- a/docs/reports.rst
+++ b/docs/reports.rst
@@ -279,7 +279,7 @@ Example of adwords query:
     {
       "name": "some_adwords_report",
       "type": "adwords",
-      "client_customer_id": "123-456-7890",
+      "client_customer_ids": "123-456-7890",
       "report_definition": {
         "reportName": "Shopping Performance Last Month",
         "dateRangeType": "THIS_MONTH",

--- a/laika/examples/adwords_config.json
+++ b/laika/examples/adwords_config.json
@@ -3,7 +3,7 @@
     {
       "name": "example_adwords_report",
       "type": "adwords",
-      "client_customer_id": "some customer id like 123-456-7890",
+      "client_customer_ids": "some customer id like 123-456-7890",
       "report_definition": {
         "reportName": "Shopping Performance Last Month",
         "dateRangeType": "THIS_MONTH",

--- a/laika/examples/config.json
+++ b/laika/examples/config.json
@@ -82,9 +82,8 @@
     }, {
       "name": "bash_query",
       "type": "bash",
-      "script": "python my_report.py",
+      "script": "ls -l",
       "result_type": "raw",
-      "connection": "local",
       "results": [
         {
           "type": "file",

--- a/laika/examples/custom_module.py
+++ b/laika/examples/custom_module.py
@@ -11,4 +11,4 @@ class BarReport(BasicReport):
 class FooResult(Result):
 
     def save(self):
-        print str(self.data)
+        print(str(self.data))

--- a/laika/examples/drive_config.json
+++ b/laika/examples/drive_config.json
@@ -5,13 +5,13 @@
       "type": "query",
       "connection": "local",
       "query_file": "query.sql",
-      "result": {
+      "results": [{
         "type": "drive",
         "filename": "report_{Y}-{m}-{d}_{H}-{M}.tsv",
         "profile": "custom_drive",
         "folder": "TestReport",
         "grant": "some_grant@mail.com"
-      }
+      }]
     }
   ]
 }

--- a/laika/reports.py
+++ b/laika/reports.py
@@ -15,11 +15,6 @@ import six
 import subprocess
 import time
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
-
 from datetime import datetime
 from dateutil.relativedelta import relativedelta, MO
 from string import Formatter

--- a/laika/reports.py
+++ b/laika/reports.py
@@ -458,7 +458,7 @@ class AdwordsReport(BasicReport):
     def process(self):
         report_downloader = self.ads_client.GetReportDownloader(version=self.adwords_service_version)
         first_client_id_processed = False
-        result = StringIO()
+        result = six.BytesIO()
         for customer_id in self.client_customer_ids:
             report_downloader.DownloadReport(
                 self.report_definition, result,

--- a/laika/reports.py
+++ b/laika/reports.py
@@ -694,7 +694,7 @@ class FileResult(Result):
             if six.PY2 or isinstance(path_or_buf, six.string_types):
                 self.data.to_csv(path_or_buf, **args)
             else:
-                # Workaround to pandas not knowing to write to BytesIO in Python 3
+                # Workaround to pandas not being able to write to BytesIO in Python 3
                 s = self.data.to_csv(**args)
                 path_or_buf.write(s.encode(self.encoding))
 

--- a/laika/reports.py
+++ b/laika/reports.py
@@ -14,7 +14,11 @@ import shlex
 import subprocess
 import time
 
-from cStringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ModuleNotFoundError:
+    from io import StringIO
+
 from datetime import datetime
 from dateutil.relativedelta import relativedelta, MO
 from string import Formatter
@@ -444,7 +448,7 @@ class AdwordsReport(BasicReport):
         self.ads_client = adwords.AdWordsClient.LoadFromStorage(creds_file)
 
     def load_report(self, name):
-        for key, report in self.conf['reports'].iteritems():
+        for key, report in self.conf['reports'].items():
             if report['type'] == 'adwords' and 'report_definition' in report:
                 definition = report['report_definition']
                 if definition['reportName'] == name:
@@ -526,9 +530,9 @@ class FacebookInsightsReport(BasicReport):
 
             status = res['async_status']
 
-            if status == u'Job Completed' and res['async_percent_completion'] == 100:
+            if status == 'Job Completed' and res['async_percent_completion'] == 100:
                 break
-            elif status == u'Job Not Started' or res['is_running']:
+            elif status == 'Job Not Started' or res['is_running']:
                 if tic % 3 == 0:
                     logging.info('Job running, completion percentage: %d', res['async_percent_completion'])
                 time.sleep(self.sleep_per_tick)
@@ -624,7 +628,7 @@ class Result(object):
     def __init__(self, conf, data, **kwargs):
         self.conf = conf
         self.data = data
-        for key, value in kwargs.iteritems():
+        for key, value in kwargs.items():
             setattr(self, key, value)
 
     def save(self):
@@ -790,7 +794,7 @@ class SendEmail(FileResult):
         message.attach(MIMEText(body, 'plain', 'utf-8'))
 
         for text in self.extra_text:
-            if isinstance(text, basestring):
+            if isinstance(text, str):
                 text = MIMEText(text, 'plain', 'utf-8')
             message.attach(text)
 
@@ -1169,7 +1173,7 @@ class Config(dict):
     }
 
     def __init__(self, config, pwd=None):
-        if isinstance(config, basestring):
+        if isinstance(config, str):
             config = json.load(open(config))
 
         self._conf = config

--- a/laika/reports.py
+++ b/laika/reports.py
@@ -419,7 +419,7 @@ class AdwordsReport(BasicReport):
     report definition from another adwords report, specifiyng reportName
     parameter.
 
-    A report is downloaded for some customer defined via client_customer_id
+    A report is downloaded for some customer defined via client_customer_ids
     parameter. If this parameter is a list of customer ids, then results are
     appendend in one report.
 
@@ -731,7 +731,8 @@ class WriteToFile(FileResult):
         logging.info('Writing result to %s', filename)
 
         if self.raw:
-            with open(filename, 'w+') as f:
+            mode = 'w+' + ('b' if isinstance(self.data, bytes) else '')
+            with open(filename, mode) as f:
                 if is_buffer(self.data):
                     self.data.seek(0)
                     copyfileobj(self.data, f)

--- a/laika/reports.py
+++ b/laika/reports.py
@@ -16,7 +16,7 @@ import time
 
 try:
     from cStringIO import StringIO
-except ModuleNotFoundError:
+except ImportError:
     from io import StringIO
 
 from datetime import datetime

--- a/laika/tests/test_formatter.py
+++ b/laika/tests/test_formatter.py
@@ -1,7 +1,11 @@
 
 from datetime import datetime
-from mock import patch, Mock
 from unittest import TestCase
+
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
 
 from laika.reports import ReportFormatter, FilenameFormatter
 
@@ -9,7 +13,7 @@ from laika.reports import ReportFormatter, FilenameFormatter
 class ReportFormatterTest(TestCase):
 
     def setUp(self):
-        now = datetime(2016, 02, 12, 18, 19, 9)
+        now = datetime(2016, 2, 12, 18, 19, 9)
         self._p_now = patch('laika.reports.ReportFormatter.get_now', Mock(return_value=now)).start()
         self.formatter = ReportFormatter({})
 
@@ -41,7 +45,7 @@ class ReportFormatterTest(TestCase):
 class FilenameFormatterTest(TestCase):
 
     def setUp(self):
-        now = datetime(2016, 02, 12, 18, 19, 9)
+        now = datetime(2016, 2, 12, 18, 19, 9)
         self._p_now = patch('laika.reports.ReportFormatter.get_now', Mock(return_value=now)).start()
         self.formatter = FilenameFormatter({})
 

--- a/laika/tests/test_laika.py
+++ b/laika/tests/test_laika.py
@@ -1,7 +1,12 @@
 
+import sys
 import pandas as pd
-from mock import patch, MagicMock
 from unittest import TestCase
+
+try:
+    from unittest.mock import patch, MagicMock, mock_open
+except ImportError:
+    from mock import patch, MagicMock, mock_open
 
 from laika.reports import Config, Runner
 
@@ -37,8 +42,8 @@ class LaikaTest(TestCase):
         }
         self.pd_sql_query = patch('pandas.read_sql_query').start()
         self.pd_write_csv = patch('pandas.DataFrame.to_csv').start()
-        # TODO: rewrite test to not use sqlalchemy
-        self.create_engine = patch('sqlalchemy.create_engine').start()
+        self.sqlalchemy_p = MagicMock()
+        patch.dict("sys.modules", sqlalchemy=self.sqlalchemy_p).start()
 
     def tearDown(self):
         patch.stopall()
@@ -50,15 +55,14 @@ class LaikaTest(TestCase):
         query = 'select foo from bar;'
         res = pd.DataFrame([[1, 1], [2, 2]])
         self.pd_sql_query.return_value = res
-        with patch('__builtin__.open', create=True) as mock_open:
-            f = MagicMock(spec=file)
-            mock_open.return_value = f
-            f.__enter__.return_value.read.return_value = query
+        open_s = '__builtin__' if sys.version_info[0] < 3 else 'builtins'
+        with patch(open_s + '.open', mock_open(read_data=query)):
             runner = Runner(config)
             runner.run()
 
-        self.create_engine.assert_called_once_with(self.config['connections'][0]['constring'])
-        expected_con = self.create_engine.return_value
+        constring = self.config['connections'][0]['constring']
+        self.sqlalchemy_p.create_engine.assert_called_once_with(constring)
+        expected_con = self.sqlalchemy_p.create_engine.return_value
         self.pd_sql_query.assert_called_once_with(query, con=expected_con)
 
         self.pd_sql_query.return_value.to_csv.assert_called_once_with('report.csv', encoding='utf-8', float_format=None, header=True, index=True)

--- a/laika/tests/test_laika.py
+++ b/laika/tests/test_laika.py
@@ -1,5 +1,5 @@
 
-import sys
+import six
 import pandas as pd
 from unittest import TestCase
 
@@ -55,7 +55,7 @@ class LaikaTest(TestCase):
         query = 'select foo from bar;'
         res = pd.DataFrame([[1, 1], [2, 2]])
         self.pd_sql_query.return_value = res
-        open_s = '__builtin__' if sys.version_info[0] < 3 else 'builtins'
+        open_s = six.moves.builtins.__name__
         with patch(open_s + '.open', mock_open(read_data=query)):
             runner = Runner(config)
             runner.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click==6.2
 pandas==0.19.2
 requests==2.9.1
+six>=1.11.0

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,16 @@ setup(
     include_package_data=True,
     classifiers=[
         'Development Status :: 3 - Alpha',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'License :: OSI Approved :: MIT License'
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6'
     ],
     tests_require=test,
     extras_require={


### PR DESCRIPTION
This pr introduces support for python 3 to laika. These changes were tested with python 2.7 and 3.5, so the library should work with python 3.5 onwards. 

The main challenge was making writing to files/buffers work on both python 2 and 3. To achieve this i make use of the `six` library. Every usage of `StringIO` was replaced with `six.BytesIO`, which translates to `StringIO` for Python 2. In Python 3 every write now requires an explicit encoding step.

This pr also contains some fixes to example definitions, and adds a few classifiers to setup.py 