### PR TITLE
Make report date overridable

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -103,6 +103,7 @@ Example of a ftp connection:
       "host": "ftp.home.com"
     }
 
+.. _global-configuration:
 
 Global configuration
 ~~~~~~~~~~~~~~~~~~~~
@@ -110,9 +111,20 @@ Global configuration
 In addition to reports, connections and profiles you can define this
 configurations:
 
+-  now: string with a datetime to use as current datetime. Useful if your
+   reports or results make use of templating to depend on dates relative to
+   current date. Must match ``%Y-%m-%d %H:%M:%S`` format.
+
 -  timezone: string of timezone to use. By default all the dates will be
    generated in UTC. You can overwrite it for each particular report.
 
 -  pwd: directory, to which laika will change before executing reports.
    In this directory it will, for example, read query files, or save
    file results (if relative path is specified).
+
+
+These configurations can be overwritten via command line arguments:
+
+.. code:: bash
+
+    $ laika.py my_report --now "2018-11-12 00:00:00"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,6 +82,8 @@ this:
 
 ``my_field`` configuration will contain ``bar`` as value.
 
+You can also overwrite :ref:`global-configuration` via command line arguments.
+
 
 Testing
 -------

--- a/laika/examples/custom_module.py
+++ b/laika/examples/custom_module.py
@@ -1,11 +1,12 @@
 
-from laika.reports import Result, BasicReport
+from laika.reports import Result, FormattedReport
 
 
-class BarReport(BasicReport):
+class BarReport(FormattedReport):
 
     def process(self):
-        return 'Wow! Such data! Much custom!'
+        current_date = self.formatter.format('{t}')
+        return 'Wow! Such data! Much custom! Even with a date: ' + current_date
 
 
 class FooResult(Result):

--- a/laika/reports.py
+++ b/laika/reports.py
@@ -140,7 +140,8 @@ class ReportFormatter(object):
     def get_now(self):
         tz = getattr(self, 'timezone', None) or self.conf.timezone
         tz = pytz.timezone(tz) if tz else pytz.utc
-        return datetime.now(tz)
+        return tz.localize(datetime.strptime(self.conf.now, '%Y-%m-%d %H:%M:%S')
+                           if self.conf.now is not None else datetime.now())
 
     def format(self, report_string):
         """
@@ -1188,8 +1189,9 @@ class Config(dict):
             config = json.load(open(config))
 
         self._conf = config
-        for key in ['timezone', 'pwd']:
-            setattr(self, key, self._conf.get(key, None))
+
+        self._global_config_fields = ['timezone', 'pwd', 'now']
+        self.overwrite_attributes(self._conf)
 
         self.pwd = self.pwd or pwd
         if self.pwd:
@@ -1227,6 +1229,14 @@ class Config(dict):
 
     def get_available_reports(self):
         return self['reports'].keys()
+
+    def overwrite_attributes(self, new_attributes):
+        """
+        Overwrites global configurations with a passed dictionary.
+        Only overwrites predefined fields.
+        """
+        for key in self._global_config_fields:
+            setattr(self, key, new_attributes.get(key, None))
 
 
 class Runner(object):

--- a/scripts/laika.py
+++ b/scripts/laika.py
@@ -55,6 +55,9 @@ def run(ctx, report, run_all, config, show_list, loglevel, pwd):
                     '\n\t- '.join(sorted(conf.get_available_reports()))) + '\n')
 
     extra_args = dict(zip(*2 * [iter(a.replace('--', '') for a in ctx.args)]))
+
+    conf.overwrite_attributes(extra_args)
+
     runner = laika.Runner(conf, **extra_args)
     if report:
         runner.run_report(report)


### PR DESCRIPTION
This pr adds:

 - `now` global configuration
 - Possibility to overwrite global configuration via CLI