### PR TITLE
Credentials in environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+ - Credentials can now be specified through environment variable
+
 ## [1.2.2] - 2019-05-17
 
  - Updated Facebook API version to 3.2

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -35,8 +35,8 @@ Profiles
 ~~~~~~~~
 
 Profiles are all kind of credentials used for accessing external APIs
-(like Google Drive). You must specify a name and a path to credentials
-for each profile. For example:
+(like Google Drive). You can specify that credentials are defined in a file
+via ``credentials`` key:
 
 .. code:: json
 
@@ -45,9 +45,9 @@ for each profile. For example:
       "credentials": "secret.json"
     }
 
-``credentials`` is always a path to a json file, but it's format depends
+In this case ``credentials`` is path to a file, but file's format depends
 on each type of report or result. For example email credentials are
-defined like this:
+defined in json format like this:
 
 .. code:: json
 
@@ -55,6 +55,39 @@ defined like this:
       "username": "me@gmail.com",
       "password": "secret"
     }
+
+Other option is to define them in an enviroment variable. By default, laika
+will search for credentials in ``LAIKA_CREDENTIALS_<profile>`` enviroment
+variable, where *<profile>* is the uppercased name of the profile. Or you can
+specify your own enviroment variable through ``env_variable`` key.
+For example, given this profile definition:
+
+.. code:: json
+
+    {
+      "name": "my_profile"
+    }
+
+Laika will look for credentials in ``LAIKA_CREDENTIALS_MY_PROFILE``. So if the
+profile you're using is that for email result, make sure you defined this
+environment variable like that:
+
+.. code:: bash
+
+    $ export LAIKA_CREDENTIALS_MY_PROFILE = '{"username": "me@gmail.com", "password": "secret"}'
+
+
+And with this definition:
+
+
+.. code:: json
+
+    {
+      "name": "my_profile",
+      "env_variable": "CUSTOM_VARIABLE"
+    }
+
+Laika will take the credentials from ``CUSTOM_VARIABLE`` enviroment variable.
 
 Connections
 ~~~~~~~~~~~

--- a/docs/reports.rst
+++ b/docs/reports.rst
@@ -151,7 +151,7 @@ parsing logic from the File report.
 
 Configuration:
 
--  profile: Name of the profile to use. It's credentials must be ones of
+-  profile: Name of the profile to use. Credentials must be ones of
    a service account with access to Google Drive's API.
 -  grant: email of a grant account, in the name of which the document
    will be downloaded. Grant must have access to specified folder.
@@ -393,7 +393,7 @@ Reported campaigns (advertisers) are all those created by the account.
 
 Configuration:
 
--  profile: Name of profile to use. Credentials file must be a json containing
+-  profile: Name of profile to use. Credentials must be a json containing
    ``username`` and ``password`` fields.
 -  day_from: Starting date for the period to retrieve costs for. You can set
    a relative date using :ref:`filenames-templating`.
@@ -435,7 +435,7 @@ Rakuten
 
 Configuration:
 
--  profile: Name of profile to use. Credentials file must be a json containing
+-  profile: Name of profile to use. Credentials must be a json containing
    ``token`` key, with a token to access Rakuten API.
 -  report_name: Existing report to download from the platform.
 -  filters: A set of filters to send to the API. Must be a dictionay, you can

--- a/docs/results.rst
+++ b/docs/results.rst
@@ -162,8 +162,8 @@ SFTP
 ``type: sftp``. Uploads the data to a SFTP server. Configurations for this
 kind of result are:
 
--  profile: Name of the profile to use. Credentials file must have
-   ``username`` and optionally ``password`` fields and/or ``private_key`` to
+-  profile: Name of the profile to use. Credentials must have ``username``
+   and optionally ``password`` fields and/or ``private_key`` to
    authenticate in the SFTP service. ``private_key`` should be a path to a file
    with the private key.
 -  connection: Name of a connection of ftp type.

--- a/laika/reports.py
+++ b/laika/reports.py
@@ -38,8 +38,7 @@ def get_json_credentials(laika_object):
     Returns parsed content of credentials file for a given report or result.
     """
     profile = laika_object.conf['profiles'][laika_object.profile]
-    with open(profile['credentials']) as f:
-        data = json.load(f)
+    data = json.loads(profile['credentials'])
     return data
 
 
@@ -496,8 +495,8 @@ class AdwordsReport(BasicReport):
 
         from googleads import adwords
 
-        creds_file = self.conf['profiles'][self.profile]['credentials']
-        self.ads_client = adwords.AdWordsClient.LoadFromStorage(creds_file)
+        creds = self.conf['profiles'][self.profile]['credentials']
+        self.ads_client = adwords.AdWordsClient.LoadFromString(creds)
 
     def load_report(self, name):
         for key, report in self.conf['reports'].items():
@@ -1078,8 +1077,9 @@ def create_drive(profile, grant):
     # Authorization method taken from here:
     # http://stackoverflow.com/questions/22555433/pydrive-and-google-drive-automate-verification-process
     logging.info('Authorizing as %s', profile['name'])
-    credentials = ServiceAccountCredentials.from_json_keyfile_name(
-        profile['credentials'], 'https://www.googleapis.com/auth/drive')
+    creds = json.loads(profile['credentials'])
+    credentials = ServiceAccountCredentials.from_json_keyfile_dict(
+        creds, 'https://www.googleapis.com/auth/drive')
     credentials.authorize(Http())
     credentials = credentials.create_delegated(grant)
     gauth = GoogleAuth()
@@ -1334,6 +1334,35 @@ class FixedColumnarResult(Result):
         self._inner_result.save()
 
 
+class Profile(six.moves.UserDict):
+    """
+    A dictionary that retrieves credentials on demand.
+    When 'credentials' key is accessed, this object will lazily read
+    credentials from a file or an environment variable.
+    """
+    _default_env_template = 'LAIKA_CREDENTIALS_{name}'
+    _contents_key = '_contents'
+
+    def _fetch_content(self):
+        creds_file = self.data.get('credentials')
+        if creds_file:
+            with open(creds_file) as f:
+                self.data[self._contents_key] = f.read()
+        else:
+            env_variable = self.data.get('env_variable')
+            if not env_variable:
+                env_variable = self._default_env_template.format(name=self['name']).upper()
+            self.data[self._contents_key] = os.environ[env_variable]
+
+    def __getitem__(self, key):
+        if key == 'credentials':
+            if self._contents_key not in self.data:
+                self._fetch_content()
+            return self.data[self._contents_key]
+
+        return self.data[key]
+
+
 class Config(dict):
     """
     Config dict with methods to retrieve some predefined configurations.
@@ -1389,8 +1418,10 @@ class Config(dict):
 
         self._update_config(config, self._get_includes(config))
 
-        for key in ['reports', 'profiles', 'connections']:
+        for key in ['reports', 'connections']:
             self[key] = {i['name']: i for i in self._conf[key]}
+
+        self['profiles'] = {p['name']: Profile(p) for p in self._conf['profiles']}
 
     def _get_includes(self, config):
         include_config = {}


### PR DESCRIPTION
This PR adds a profile abstraction, that loads credentials lazily. 

It first looks for a file, defined in `credentials` key; if that key is not specified, it looks for the enviroment variable `env_variable`; and if that key is not specified, it looks in `LAIKA_CREDENTIALS_<profile>` env variable, where *<profile>* is the name of the profile.