### PR TITLE
Use rest API instead of sdk in RTBHouse report

### DIFF
--- a/docs/reports.rst
+++ b/docs/reports.rst
@@ -392,9 +392,6 @@ Example of facebook report:
 RTBHouse
 ^^^^^^^^
 
-.. note:: To use rtbhouse report you must install ``rtbhouse`` dependency:
-    ``pip install laika-lib[rtbhouse]``
-
 ``type: rtbhouse``. Downloads marketing costs report from RTBHouse API.
 Reported campaigns (advertisers) are all those created by the account.
 

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,8 @@ drive = ['PyDrive==1.3.1']
 adwords = ['googleads==19.0.0']
 s3 = ['boto3==1.4.3']
 sftp = ['paramiko==2.6.0']
-rtbhouse = ['rtbhouse_sdk==3.0.1']
 
-all_reports = excel + postgres + presto + drive + adwords + s3 + sftp + rtbhouse
+all_reports = excel + postgres + presto + drive + adwords + s3 + sftp
 
 test = ['mock==1.3.0']
 docs = ['Sphinx>=1.7.1', 'sphinx-rtd-theme>=0.2.4']
@@ -72,7 +71,6 @@ setup(
         'adwords': adwords,
         's3': s3,
         'sftp': sftp,
-        'rtbhouse': rtbhouse,
 
         'all_reports': all_reports,
 


### PR DESCRIPTION
Because rtbhouse sdk dropped Python 2 support i rewrite our RTBHouse report to use rest API directly. The logic is mostly taken from their [reports_api.py](https://github.com/rtbhouse-apps/rtbhouse-python-sdk/blob/master/rtbhouse_sdk/reports_api.py).