### PR TITLE
Fix google api httplib2 issue and bump version to 1.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.3.7] - 2020-02-03
+
+ - Fixed interaction between google api and httlib2 libraries
+
 ## [1.3.6] - 2020-01-30
 
  - Added support for shared drives in Google Drive report and result

--- a/laika/__init__.py
+++ b/laika/__init__.py
@@ -1,4 +1,4 @@
 
-__version__ = '1.3.6'
+__version__ = '1.3.7'
 
 from laika.reports import Config, Runner


### PR DESCRIPTION
The issue and the workaround proposal are described [here](https://stackoverflow.com/questions/59815620/gcloud-upload-httplib2-redirectmissinglocation-redirected-but-the-response-is-m)