### PR TITLE
Add overwrite to query variables

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,6 +82,12 @@ this:
 
 ``my_field`` configuration will contain ``bar`` as value.
 
+The argument ``variables`` can also be overwritten, but it requires a valid json:
+
+.. code:: bash
+
+    $ laika.py my_report --variables '{"bar": "foo"}'
+
 You can also overwrite :ref:`global-configuration` via command line arguments.
 
 

--- a/docs/reports.rst
+++ b/docs/reports.rst
@@ -58,8 +58,8 @@ with PostgreSQL and Presto. These are the configurations:
 -  query\_file: path to a file that contains plane sql code. Will be ignored if
    query is specified.
 -  connection: name of the connection to use.
--  variables: A dictionary with values to replace in query code. You can
-   find further explanation in :ref:`query-templating`.
+-  variables: A dictionary with values to replace in query code. It can be overwritten
+   via the cli. You can find further explanation in :ref:`query-templating`.
 
 Example of a query report:
 

--- a/docs/reports.rst
+++ b/docs/reports.rst
@@ -58,8 +58,8 @@ with PostgreSQL and Presto. These are the configurations:
 -  query\_file: path to a file that contains plane sql code. Will be ignored if
    query is specified.
 -  connection: name of the connection to use.
--  variables: A dictionary with values to replace in query code. It can be overwritten
-   via the cli. You can find further explanation in :ref:`query-templating`.
+-  variables: A dictionary with values to replace in query code. You can find
+   further explanation in :ref:`query-templating`.
 
 Example of a query report:
 

--- a/docs/templating.rst
+++ b/docs/templating.rst
@@ -99,6 +99,12 @@ dates, so you can define in your configuration variables like this:
 
 ``{yesterday}`` will be converted into ``2016-02-12 17:19:09``.
 
+Variables can be overwritten via the cli providing a json:
+
+.. code:: bash
+
+    $ laika.py my_report --variables '{"my_var": "new value"}'
+
 .. _filenames-templating:
 
 Filenames templating

--- a/docs/templating.rst
+++ b/docs/templating.rst
@@ -99,12 +99,6 @@ dates, so you can define in your configuration variables like this:
 
 ``{yesterday}`` will be converted into ``2016-02-12 17:19:09``.
 
-Variables can be overwritten via the cli providing a json:
-
-.. code:: bash
-
-    $ laika.py my_report --variables '{"my_var": "new value"}'
-
 .. _filenames-templating:
 
 Filenames templating

--- a/scripts/laika.py
+++ b/scripts/laika.py
@@ -5,6 +5,7 @@ import click
 import logging
 import os
 import sys
+import json
 
 # Temporary fix to use script having same name as the module
 if os.path.dirname(os.path.realpath(__file__)) == sys.path[0]:
@@ -56,6 +57,9 @@ def run(ctx, report, run_all, config, show_list, loglevel, pwd):
                     '\n\t- '.join(sorted(conf.get_available_reports()))) + '\n')
 
     extra_args = dict(zip(*2 * [iter(a.replace('--', '') for a in ctx.args)]))
+
+    if 'variables' in extra_args:
+        extra_args['variables'] = json.loads(extra_args['variables'])
 
     conf.overwrite_attributes(extra_args)
 


### PR DESCRIPTION
To do this you have to provide a valid json when calling the report.
For example:
`laika.py my_report --variables '{"foo": "bar"}'`