### PR TITLE
Use replace instead of format for variables in ReportFormatter

### DIFF
--- a/laika/reports.py
+++ b/laika/reports.py
@@ -134,8 +134,8 @@ class ReportFormatter(object):
         return value.strftime('%Y-%m-%d %H:%M:%S')
 
     def _apply_variables(self, report_string):
-        if self.variables:
-            report_string = report_string.format(**self.variables)
+        for k, v in self.variables.items():
+            report_string = report_string.replace('{' + k + '}', str(v))
         return report_string
 
     def get_now(self):
@@ -979,7 +979,7 @@ class FileResult(Result):
     index = True
     float_format = None
     header = True
-    result_variables = None
+    result_variables = {}
     extra_args = {}
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
variables/result_variables can be used by several strings if one of them doesn't contain one of the keys it fails

e.g.:

```python
d = {'a': 'user', 'b': 'laika'}
email_subject = 'hello {a}, from {b}'
email_body = 'Nice to meet you!'
email_subject.format(**d)
email_body.format(**d) # fails
```

For that reason we are changing from format to replace.