### PR TITLE
Change action_attribution_windows from 28d to 7d

### DIFF
--- a/laika/reports.py
+++ b/laika/reports.py
@@ -638,8 +638,9 @@ class FacebookInsightsReport(BasicReport):
         'limit': 10000000,
         'filtering': '[{"operator": "NOT_IN", "field": "ad.effective_status", "value": ["DELETED"]}]',
         'fields': 'impressions,reach',
-        'action_attribution_windows': '28d_click'
+        'action_attribution_windows': '7d_click'
     }
+
     api_version = 'v12.0'
     base_url = 'https://graph.facebook.com/{}/{}'
     endpoint = '/insights'


### PR DESCRIPTION
https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/v12.0

Metrics will be available if querying with action_attribution_windows=1d_click,7d_click,1d_view